### PR TITLE
Run kernel with launcher

### DIFF
--- a/assembly/zip/install.py
+++ b/assembly/zip/install.py
@@ -169,24 +169,23 @@ if __name__ == '__main__':
         replace=args.replace
     )
 
-    # Connect the self referencing token left in the kernel.json to point to it's install location.
-
-    # Prepare the token replacement string which should be properly escaped for use in a JSON string
+    # Prepare token replacement strings which should be properly escaped for use in a JSON string
     # The [1:-1] trims the first and last " json.dumps adds for strings.
-    install_dest_json_fragment = json.dumps(install_dest)[1:-1]
+    executable_path = json.dumps(sys.executable)[1:-1]
+    launcher_path = json.dumps(os.path.join(install_dest, 'launcher.py'))[1:-1]
+    kernel_path = json.dumps(os.path.join(install_dest, '${project.build.finalName}.jar'))[1:-1]
 
     # Prepare the paths to the installed kernel.json and the one bundled with this installer.
     local_kernel_json_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'java', 'kernel.json')
     installed_kernel_json_path = os.path.join(install_dest, 'kernel.json')
 
-    # Replace the @KERNEL_INSTALL_DIRECTORY@ token with the path to where the kernel was installed
-    # in the installed kernel.json from the local template.
+    # Replace tokens in the installed kernel.json.
     with open(local_kernel_json_path, 'r') as template_kernel_json_file:
         template_kernel_json_contents = template_kernel_json_file.read()
-        kernel_json_contents = template_kernel_json_contents.replace(
-            '@KERNEL_INSTALL_DIRECTORY@',
-            install_dest_json_fragment
-        )
+        kernel_json_contents = template_kernel_json_contents.replace('@PY_EXECUTABLE@', executable_path)
+        kernel_json_contents = kernel_json_contents.replace('@LAUNCHER_PATH@', launcher_path)
+        kernel_json_contents = kernel_json_contents.replace('@KERNEL_PATH@', kernel_path)
+        print(kernel_json_contents)
         kernel_json_json_contents = json.loads(kernel_json_contents)
         kernel_env = kernel_json_json_contents.setdefault('env', {})
         for k, v in args.env.items():

--- a/assembly/zip/kernel.json
+++ b/assembly/zip/kernel.json
@@ -1,10 +1,8 @@
 {
     "argv": [
-        "java",
-        "--add-opens",
-        "jdk.jshell/jdk.jshell=ALL-UNNAMED",
-        "-jar",
-        "@KERNEL_INSTALL_DIRECTORY@/${project.build.finalName}.jar",
+        "@PY_EXECUTABLE@",
+        "@LAUNCHER_PATH@",
+        "@KERNEL_PATH@",
         "{connection_file}"
     ],
     "display_name": "Java",

--- a/assembly/zip/launcher.py
+++ b/assembly/zip/launcher.py
@@ -1,0 +1,21 @@
+import sys
+import os
+import subprocess
+
+
+def launch_kernel():
+    kernel_path = sys.argv[1]
+    connection_file = sys.argv[2]
+    jvm_options = os.getenv('JJ_JVM_OPTS', '')
+
+    subprocess.run(['java',
+                    jvm_options,
+                    '--add-opens',
+                    'jdk.jshell/jdk.jshell=ALL-UNNAMED',
+                    '-jar',
+                    kernel_path,
+                    connection_file])
+
+
+if __name__ == '__main__':
+    launch_kernel()

--- a/assembly/zip/zip.xml
+++ b/assembly/zip/zip.xml
@@ -12,13 +12,17 @@
             <outputDirectory>java</outputDirectory>
         </file>
         <file>
+            <source>assembly/zip/launcher.py</source>
+            <outputDirectory>java</outputDirectory>
+        </file>
+        <file>
             <source>assembly/zip/kernel.json</source>
             <outputDirectory>java</outputDirectory>
-            <filtered>true</filtered>
         </file>
         <file>
             <source>assembly/zip/install.py</source>
             <outputDirectory>/</outputDirectory>
+            <filtered>true</filtered>
         </file>
     </files>
 </assembly>


### PR DESCRIPTION
This PR makes the kernel run from a launcher that allows us to pass jvm options using `JJ_JVM_OPTS` env var (mostly like it was mentioned in #12).

### Example

Windows:
```
set JJ_JVM_OPTS=-Xlog:gc
jupyter notebook
```

Linux
```
JJ_JVM_OPTS=-Xlog:gc jupyter notebook
```