### PR TITLE
Remove module-info.class shade warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
                         <filter>
                             <artifact>*</artifact>
                             <excludes>
+                                <exclude>module-info.class</exclude>
                                 <exclude>META-INF/*.MF</exclude>
                                 <exclude>META-INF/DEPENDENCIES</exclude>
                             </excludes>


### PR DESCRIPTION
This PR removes shade plugin warning.
```
[WARNING] Discovered module-info.class. Shading will break its strong encapsulation.
```