### PR TITLE
Let launcher print start up args

### DIFF
--- a/assembly/zip/launcher.py
+++ b/assembly/zip/launcher.py
@@ -11,11 +11,9 @@ def launch_kernel():
 
     jvm_options = os.getenv('JJAVA_JVM_OPTS', '')
     if jvm_options:
-        i = 0
-        for opt in jvm_options.split(' '):
-            i += 1
-            args.insert(i, opt)
+        args[1:1] = jvm_options.split(r'\s+')
 
+    print(f"Running JJava Kernel with args: {args}")
     subprocess.run(args)
 
 


### PR DESCRIPTION
## About this PR:
Enables logging of start up args for the kernel launcher. +1 point to convenient development

## Testing

Here is an example of output:
```
[I 2024-08-19 15:16:41.943 ServerApp] Kernel started: e97abfb3-fcc6-4c62-9466-7666e12975c4
Running JJava Kernel with args: ['java', '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5005', '--add-opens', 'jdk.jshell/jdk.jshell=ALL-UNNAMED', '-jar', 'C:\\ProgramData\\jupyter\\kernels\\java\\jjava-1.0-SNAPSHOT.jar', 'C:\\Users\\mdzianishchyts\\AppData\\Roaming\\jupyter\\runtime\\kernel-e97abfb3-fcc6-4c62-9466-7666e12975c4.json']
Listening for transport dt_socket at address: 5005
```