### PR TITLE
Modify 'java.class.path' property at runtime

### DIFF
--- a/jjava/src/main/java/org/dflib/jjava/execution/JJavaLoaderDelegate.java
+++ b/jjava/src/main/java/org/dflib/jjava/execution/JJavaLoaderDelegate.java
@@ -14,6 +14,8 @@ import java.util.Map;
 
 public class JJavaLoaderDelegate implements LoaderDelegate {
 
+    private static final String CLASSPATH_PROPERTY = "java.class.path";
+
     private final Map<String, byte[]> declaredClasses;
     private final Map<String, Class<?>> loadedClasses;
     private final BytecodeClassLoader classLoader;
@@ -54,6 +56,10 @@ public class JJavaLoaderDelegate implements LoaderDelegate {
         for (String next : path.split(File.pathSeparator)) {
             try {
                 classLoader.addURL(Path.of(next).toUri().toURL());
+
+                String classpath = System.getProperty(CLASSPATH_PROPERTY);
+                classpath += System.lineSeparator() + path;
+                System.setProperty(CLASSPATH_PROPERTY, classpath);
             } catch (MalformedURLException e) {
                 throw new ExecutionControl.InternalException("Unable to resolve classpath " + next
                         + ": " + e.getMessage());


### PR DESCRIPTION
## About this PR
Fixes #29 by modifying system property when jar is added to the classloader's URLs.

## Testing
The property contains other jars except of the kernel one.

![image](https://github.com/user-attachments/assets/2b08e4cb-b36a-4f4e-acb8-461f75baebf1)
