### PR TITLE
Add styling  BOLD_RESET_FG (black un Jupyter Lab, white un VSCode)

### DIFF
--- a/jjava/src/main/java/org/dflib/jjava/JavaKernel.java
+++ b/jjava/src/main/java/org/dflib/jjava/JavaKernel.java
@@ -146,12 +146,12 @@ public class JavaKernel extends BaseKernel {
         );
 
         this.errorStyler = new StringStyler.Builder()
-                .addPrimaryStyle(TextColor.BOLD_BLACK_FG)
+                .addPrimaryStyle(TextColor.BOLD_RESET_FG)
                 .addSecondaryStyle(TextColor.BOLD_RED_FG)
-                .addHighlightStyle(TextColor.BOLD_BLACK_FG)
+                .addHighlightStyle(TextColor.BOLD_RESET_FG)
                 .addHighlightStyle(TextColor.RED_BG)
                 //TODO map snippet ids to code cells and put the proper line number in the margin here
-                .withLinePrefix(TextColor.BOLD_BLACK_FG + "|   ")
+                .withLinePrefix(TextColor.BOLD_RESET_FG + "|   ")
                 .build();
 
         this.mavenResolver.initImplicitExtensions();

--- a/jupyter-jvm-basekernel/src/main/java/org/dflib/jjava/jupyter/kernel/BaseKernel.java
+++ b/jupyter-jvm-basekernel/src/main/java/org/dflib/jjava/jupyter/kernel/BaseKernel.java
@@ -107,9 +107,9 @@ public abstract class BaseKernel {
         Text.registerAll(this.renderer);
 
         this.errorStyler = new StringStyler.Builder()
-                .addPrimaryStyle(TextColor.BOLD_BLACK_FG)
+                .addPrimaryStyle(TextColor.BOLD_RESET_FG)
                 .addSecondaryStyle(TextColor.BOLD_RED_FG)
-                .addHighlightStyle(TextColor.BOLD_BLACK_FG)
+                .addHighlightStyle(TextColor.BOLD_RESET_FG)
                 .addHighlightStyle(TextColor.RED_BG)
                 .build();
     }

--- a/jupyter-jvm-basekernel/src/main/java/org/dflib/jjava/jupyter/kernel/util/TextColor.java
+++ b/jupyter-jvm-basekernel/src/main/java/org/dflib/jjava/jupyter/kernel/util/TextColor.java
@@ -32,6 +32,8 @@ public enum TextColor {
     WHITE_BG(47),
     RESET_BG(49),
 
+    BOLD_RESET_FG(39, 1),
+
     BOLD(1),
     UNDERLINE(4),
     SWAP_FG_BG(7),


### PR DESCRIPTION
Change use of BOLD_BLACK_FG to BOLD_RESET_FG for improved visibility.
Rationale in #57 