### PR TITLE
Fix installation via Homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,35 +32,41 @@ jobs:
         with:
           homebrew_owner: dflib
           homebrew_tap: homebrew-tap
-          version: ${{ github.ref_name }}
           depends_on: |
-            "jupyterlab"
+            "jupyterlab" => :test
             "expect" => :test
           target: jjava-${{ github.ref_name }}-kernelspec.zip
           install: |
             libexec.install Dir["*.jar"]
             config = buildpath/"kernel.json"
             inreplace config, "{resource_dir}", libexec
-            system "jupyter kernelspec install #{buildpath} --config=#{config} --sys-prefix --name=java"
+            (share/"jupyter/kernels/java").install config
+          caveats: |
+            kernel_path = share/"jupyter"
+            <<~EOS
+              The installation of the Homebrew package takes place in an isolated environment, so ensure JJava visibility by running:
+                echo 'export JUPYTER_PATH="#{kernel_path}:$JUPYTER_PATH"' >> ~/.zshrc; source ~/.zshrc (macOS)
+                echo 'export JUPYTER_PATH="#{kernel_path}:$JUPYTER_PATH"' >> ~/.bashrc; source ~/.bashrc (Linux)
+              Although JJava doesn't depend on java, it requires jre>=11 to run.
+              Make sure you have one in your PATH.
+            EOS
           test: |
             jupyter = Formula["jupyterlab"].opt_bin/"jupyter"
+            ENV["JUPYTER_PATH"] = share/"jupyter"
             assert_match " java ", shell_output("#{jupyter} kernelspec list")
 
             (testpath/"console.exp").write <<~EOS
               spawn #{jupyter} console --kernel=java
               expect -timeout 30 "In "
-              send "System.out.println(\\\"Hello world!\\\");\r"
+              send {System.out.println("Hello world!");\r}
               expect -timeout 10 "In "
               send "\u0004"
               expect -timeout 10 "exit"
               send "y\r"
-              EOS
+            EOS
             output = shell_output("expect -f console.exp")
             assert_match "JJava kernel #{version}", output
             assert_match "Hello world!", output
-          caveats: |
-            Although JJava doesn't depend on java, it requires jre>=11 to run.
-            Make sure you have one in your PATH.
           update_readme_table: true
           github_token: ${{ secrets.HOMEBREW_RELEASE_ACCESS_TOKEN }}
           debug: ${{ runner.debug }}


### PR DESCRIPTION
## What does this PR do?

Updates the Homebrew formula to fix JJava installation on macOS and ensure the formula passes a strict audit check.
The Homebrew installation must be manually completed by updating the JUPYTER_PATH environment variable from now.

The main reason for this is that Homebrew installs packages in a highly isolated environment, which limits many convenient ways of installing Jupyter kernels. We address this with a compromise between convenience and error tolerance.

Fixes #52.

## Testing

Successful installation using my test formula on both Ubuntu and macOS:
```
brew install m-dzianishchyts/jjava/jjava
```