### PR TITLE
mutual dependent class not working #65

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,6 @@
 ## 1.0-a6
 
+- #65 mutual dependent class not working
 - #68 CompilationException doesn't provide any information about the udnerlying problem
 - #69 Expose EvalException details
 

--- a/jjava/src/main/java/org/dflib/jjava/execution/CodeEvaluator.java
+++ b/jjava/src/main/java/org/dflib/jjava/execution/CodeEvaluator.java
@@ -148,8 +148,12 @@ public class CodeEvaluator {
                     throw new RuntimeException(e);
                 }
 
-                if (!event.status().isDefined())
+                // Undefined snippets are generally bad, unless we can still recover from them. E.g.,
+                // "Unresolved dependencies" errors are recoverable when those dependencies are defined in the later
+                // snippets.
+                if (event.status() != Snippet.Status.RECOVERABLE_NOT_DEFINED && !event.status().isDefined()) {
                     throw new CompilationException(event);
+                }
             }
         }
 


### PR DESCRIPTION
@stariy95 , I was address a part of the issue - avoiding failures in the declaration snippet. However an attempt to instantiate on of the declared classes in the following cell still throws. So we need to dig a bit deeper.

```java
new Animal();
```

```
java.lang.RuntimeException: java.lang.NoClassDefFoundError, REPL[/](http://localhost:8888/)$JShell$13$Animal
	at org.dflib.jjava.execution.CodeEvaluator.evalSingle(CodeEvaluator.java:144)
	at org.dflib.jjava.execution.CodeEvaluator.eval(CodeEvaluator.java:176)
	at org.dflib.jjava.JavaKernel.evalRaw(JavaKernel.java:337)
	at org.dflib.jjava.JavaKernel.eval(JavaKernel.java:342)
	at org.dflib.jjava.jupyter.kernel.BaseKernel.handleExecuteRequest(BaseKernel.java:383)
	at org.dflib.jjava.jupyter.channels.ShellChannel.lambda$bind$0(ShellChannel.java:64)
	at org.dflib.jjava.jupyter.channels.Loop.lambda$new$0(Loop.java:21)
	at org.dflib.jjava.jupyter.channels.Loop.run(Loop.java:78)
Caused by: jdk.jshell.EvalException: REPL[/](http://localhost:8888/)$JShell$13$Animal
	at .(#31:1)
```

