### PR TITLE
Magic parser fixes

### DIFF
--- a/jupyter-jvm-basekernel/src/main/java/org/dflib/jjava/jupyter/kernel/magic/MagicParser.java
+++ b/jupyter-jvm-basekernel/src/main/java/org/dflib/jjava/jupyter/kernel/magic/MagicParser.java
@@ -40,7 +40,7 @@ public class MagicParser {
                         current.append('"');
                         escape = false;
                     } else {
-                        if (current.length() > 0 && inQuotes) {
+                        if (inQuotes) {
                             split.add(current.toString());
                             current.setLength(0);
                             inQuotes = false;

--- a/jupyter-jvm-basekernel/src/main/java/org/dflib/jjava/jupyter/kernel/magic/MagicParser.java
+++ b/jupyter-jvm-basekernel/src/main/java/org/dflib/jjava/jupyter/kernel/magic/MagicParser.java
@@ -29,7 +29,7 @@ public class MagicParser {
                     break;
                 case '\\':
                     if (escape) {
-                        current.append("\\\\");
+                        current.append("\\");
                         escape = false;
                     } else {
                         escape = true;


### PR DESCRIPTION
fixed two bugs in magic parser in two separate commits:
- escaped backslash (was wrongly translated to '\\')
- empty quoted strings (were not possible)

