### PR TITLE
Eval startup snippets explicitly

### DIFF
--- a/jjava-distro/pom.xml
+++ b/jjava-distro/pom.xml
@@ -39,6 +39,11 @@
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/jjava-distro/src/main/java/org/dflib/jjava/distro/JJava.java
+++ b/jjava-distro/src/main/java/org/dflib/jjava/distro/JJava.java
@@ -55,7 +55,6 @@ public class JJava {
                 .version((String) pomProps.getOrDefault("version", ""))
 
                 .extensionsEnabled(Env.extensionsEnabled())
-                .startupSnippets(Env.startupSnippets())
                 .compilerOpts(Env.compilerOpts())
                 .timeout(Env.timeout())
 
@@ -78,6 +77,9 @@ public class JJava {
 
         // process custom locations: expand JShell classpath, install extensions from those places (if enabled)
         kernel.addToClasspath(Env.extraClasspath());
+
+        // run user defined startup snippets explicitly after the default startup
+        Env.startupSnippets().forEach(kernel::evalRaw);
 
         // connect to Jupyter
         kernel.becomeHandlerForConnection(connection);

--- a/jjava-distro/src/test/java/org/dflib/jjava/distro/KernelStartupIT.java
+++ b/jjava-distro/src/test/java/org/dflib/jjava/distro/KernelStartupIT.java
@@ -3,9 +3,12 @@ package org.dflib.jjava.distro;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.Container;
 
+import java.util.Map;
+
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
 
 public class KernelStartupIT extends ContainerizedKernelCase {
 
@@ -16,5 +19,18 @@ public class KernelStartupIT extends ContainerizedKernelCase {
 
         assertThat(snippetResult.getStderr(), not(containsString("|")));
         assertThat(snippetResult.getStdout(), containsString("1001.0"));
+    }
+
+    @Test
+    void startUp_scriptRequiresClasspath() throws Exception {
+        Map<String, String> env = Map.of(
+                Env.JJAVA_CLASSPATH, TEST_CLASSPATH,
+                Env.JJAVA_STARTUP_SCRIPT, "var obj = new org.dflib.jjava.Dummy()"
+        );
+        String snippet = "\"hash = \" + obj.hashCode()";
+        Container.ExecResult snippetResult = executeInKernel(snippet, env);
+
+        assertThat(snippetResult.getStdout(), not(containsString("|")));
+        assertThat(snippetResult.getStdout(), matchesPattern("(?s).*hash = -?\\d+.*"));
     }
 }

--- a/jjava-jupyter/pom.xml
+++ b/jjava-jupyter/pom.xml
@@ -39,7 +39,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-all</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jjava-kernel/src/main/java/org/dflib/jjava/kernel/JavaKernelBuilder.java
+++ b/jjava-kernel/src/main/java/org/dflib/jjava/kernel/JavaKernelBuilder.java
@@ -82,7 +82,7 @@ public abstract class JavaKernelBuilder<
     }
 
     protected CodeEvaluator buildCodeEvaluator(JShell jShell, JJavaExecutionControlProvider jShellExecControlProvider) {
-        return new CodeEvaluator(jShell, jShellExecControlProvider, jShellExecControlID, startupSnippets);
+        return new CodeEvaluator(jShell, jShellExecControlProvider, jShellExecControlID);
     }
 
     protected MagicParser buildMagicParser(MagicTranspiler transpiler) {

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <commons.logging.version>1.3.5</commons.logging.version>
 
         <junit5.version>5.11.2</junit5.version>
-        <hamcrest.version>1.3</hamcrest.version>
+        <hamcrest.version>3.0</hamcrest.version>
         <jimfs.version>1.3.0</jimfs.version>
         <testcontainers.version>1.21.3</testcontainers.version>
         <slf4j.version>2.0.17</slf4j.version>
@@ -131,7 +131,7 @@
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-all</artifactId>
+                <artifactId>hamcrest</artifactId>
                 <version>${hamcrest.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
## What does this PR do?

Removes implicit execution of startup snippets from [CodeEvaluator](https://github.com/m-dzianishchyts/jjava/blob/3020714dc9181e83ac875833d8a341c5b5b41883/jjava-kernel/src/main/java/org/dflib/jjava/kernel/execution/CodeEvaluator.java).
Executes user-defined startup snippets explicitly during the kernel boot sequence.

Implicit execution could run before `JJAVA_CLASSPATH` was applied, causing failures when snippets reference classes from extra classpath.
Explicit control guarantees correct ordering: default extensions -> extra classpath/extensions -> startup snippets.

Fixes #67.