### PR TITLE
fixed path separator handling in test for windows compatibility

### DIFF
--- a/jjava-jupyter/src/test/java/org/dflib/jjava/jupyter/kernel/util/PathsHandlerTest.java
+++ b/jjava-jupyter/src/test/java/org/dflib/jjava/jupyter/kernel/util/PathsHandlerTest.java
@@ -30,16 +30,17 @@ public class PathsHandlerTest {
         Files.createFile(dir.resolve("b2.txt"));
         Files.createFile(dir.resolve("c1.txt"));
 
-        String basePath = dir + File.separator;
+        // GlobResolver requires "/" as path separator (also on Windows)
+        String basePath = dir.toString().replace(File.separator, "/") + "/";
 
         assertEquals(List.of(), PathsHandler.splitAndResolveGlobs(""));
         assertEquals(List.of(), PathsHandler.splitAndResolveGlobs(basePath + "a"));
         assertEquals(List.of(), PathsHandler.splitAndResolveGlobs(basePath + "a" + File.pathSeparator + "b/c/d"));
 
         assertEquals(List.of(basePath + "a1.txt", basePath + "a2.txt"),
-                PathsHandler.splitAndResolveGlobs(basePath + "a*").stream().map(p -> p.toAbsolutePath().toString()).sorted().collect(Collectors.toList()));
+                PathsHandler.splitAndResolveGlobs(basePath + "a*").stream().map(p -> p.toAbsolutePath().toString().replace(File.separator, "/")).sorted().collect(Collectors.toList()));
         assertEquals(
                 List.of(basePath + "a1.txt", basePath + "a2.txt", basePath + "b1.txt", basePath + "b2.txt"),
-                PathsHandler.splitAndResolveGlobs(basePath + "a*" + File.pathSeparator + basePath + "b*").stream().map(p -> p.toAbsolutePath().toString()).sorted().collect(Collectors.toList()));
+                PathsHandler.splitAndResolveGlobs(basePath + "a*" + File.pathSeparator + basePath + "b*").stream().map(p -> p.toAbsolutePath().toString().replace(File.separator, "/")).sorted().collect(Collectors.toList()));
     }
 }


### PR DESCRIPTION
This is basically a duplicate of https://github.com/dflib/jjava/pull/98, but only fixes the path issue... locally, I can run the tests without further adjustments, maybe because of 31f1e97 (Testcontainers 2.0).
