### PR TITLE
Prevent variable nullification on later imports

### DIFF
--- a/jjava-distro/src/test/java/org/dflib/jjava/distro/KernelExecutionIT.java
+++ b/jjava-distro/src/test/java/org/dflib/jjava/distro/KernelExecutionIT.java
@@ -1,0 +1,25 @@
+package org.dflib.jjava.distro;
+
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.Container;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class KernelExecutionIT extends ContainerizedKernelCase {
+
+    /**
+     * @see <a href="https://github.com/dflib/jjava/issues/119">#119</a>
+     */
+    @Test
+    public void variableSurvivesLaterImports() throws Exception {
+        String snippet = "%load " + CONTAINER_RESOURCES + "/nullifying_import.jshell";
+
+        Container.ExecResult snippetResult = executeInKernel(snippet);
+
+        assertEquals(0, snippetResult.getExitCode(), snippetResult.getStdout());
+        assertThat(snippetResult.getStdout(), not(containsString("|")));
+    }
+}

--- a/jjava-distro/src/test/resources/nullifying_import.jshell
+++ b/jjava-distro/src/test/resources/nullifying_import.jshell
@@ -1,5 +1,5 @@
-%maven tools.jackson.core:jackson-databind:3.1.2
-import tools.jackson.databind.*; import tools.jackson.databind.json.*;
-var om = JsonMapper.builder().findAndAddModules().build();
-import tools.jackson.databind.node.*; import tools.jackson.databind.type.*;
+%maven com.fasterxml.jackson.core:jackson-databind:2.21.2
+import com.fasterxml.jackson.databind.*;
+var om = new ObjectMapper().findAndRegisterModules();
+import com.fasterxml.jackson.databind.node.*; import com.fasterxml.jackson.databind.type.*;
 om.getClass().getName()

--- a/jjava-distro/src/test/resources/nullifying_import.jshell
+++ b/jjava-distro/src/test/resources/nullifying_import.jshell
@@ -1,0 +1,5 @@
+%maven tools.jackson.core:jackson-databind:3.1.2
+import tools.jackson.databind.*; import tools.jackson.databind.json.*;
+var om = JsonMapper.builder().findAndAddModules().build();
+import tools.jackson.databind.node.*; import tools.jackson.databind.type.*;
+om.getClass().getName()

--- a/jjava-kernel/src/main/java/org/dflib/jjava/kernel/execution/JJavaExecutionControl.java
+++ b/jjava-kernel/src/main/java/org/dflib/jjava/kernel/execution/JJavaExecutionControl.java
@@ -76,6 +76,11 @@ class JJavaExecutionControl extends DirectExecutionControl {
         executor.shutdownNow();
     }
 
+    @Override
+    public void redefine(ClassBytecodes[] cbcs) {
+        loaderDelegate.classesRedefined(cbcs);
+    }
+
     public Object takeResult(String id) {
         Object result = this.results.remove(id);
         if (result == null) {


### PR DESCRIPTION
## What does this PR do?

Fixes #119.

## Details

When JShell needs to recompile an earlier snippet due to a later snippet affecting its type context (e.g., new wildcard imports), it calls `ExecutionControl.redefine()` to hot-swap the wrapper class bytecode. The inherited `DirectExecutionControl.redefine()` unconditionally throws `NotImplementedException`. JShell then falls back to installing a new wrapper class without re-running the initializer, silently zeroing the static field that backs the user's variable.

We can acknowledge the redefinition and only update the loader's bytecode cache. The already-loaded class stays in place, its static fields are preserved. Subsequent snippets are compiled against the recompiled wrapper's signature, which for import-driven recompilations is equivalent to the original, so field and method resolution keeps working against the existing loaded class.

## Testing

Integration test reproduces the bug in a single-cell Jupyter execution. Passes with the fix.