### PR TITLE
Use wrapping exceptions to fix truncated stack traces

### DIFF
--- a/jjava-kernel/src/main/java/org/dflib/jjava/kernel/JavaKernel.java
+++ b/jjava-kernel/src/main/java/org/dflib/jjava/kernel/JavaKernel.java
@@ -127,6 +127,8 @@ public class JavaKernel extends BaseKernel {
             return formatEvaluationTimeoutException((EvaluationTimeoutException) e);
         } else if (e instanceof EvaluationInterruptedException) {
             return formatEvaluationInterruptedException((EvaluationInterruptedException) e);
+        } else if (e instanceof RuntimeException && e.getCause() instanceof EvalException) {
+            return formatEvalException((EvalException) e.getCause());
         } else {
             return new ArrayList<>(super.formatError(e));
         }
@@ -180,14 +182,28 @@ public class JavaKernel extends BaseKernel {
     private List<String> formatEvalException(EvalException e) {
         List<String> fmt = new ArrayList<>();
 
-
-        String evalExceptionClassName = EvalException.class.getName();
         String actualExceptionName = e.getExceptionClassName();
-        super.formatError(e).stream()
-                .map(line -> line.replace(evalExceptionClassName, actualExceptionName))
-                .forEach(fmt::add);
+        fmt.add(errorStyler.secondary(actualExceptionName + ": " + e.getMessage()));
+        for (StackTraceElement element : e.getStackTrace()) {
+            fmt.add(errorStyler.secondary("\tat " + element));
+        }
 
+        formatEvalExceptionCause((EvalException) e.getCause(), fmt);
         return fmt;
+    }
+
+    private void formatEvalExceptionCause(EvalException e, List<String> fmt) {
+        if (e == null) {
+            return;
+        }
+
+        String actualExceptionName = e.getExceptionClassName();
+        fmt.add(errorStyler.secondary("Caused by: " + actualExceptionName + ": " + e.getMessage()));
+        for (StackTraceElement element : e.getStackTrace()) {
+            fmt.add(errorStyler.secondary("\tat " + element));
+        }
+        
+        formatEvalExceptionCause((EvalException) e.getCause(), fmt);
     }
 
     private List<String> formatUnresolvedReferenceException(UnresolvedReferenceException e) {

--- a/jjava-kernel/src/main/java/org/dflib/jjava/kernel/execution/JJavaExecutionControl.java
+++ b/jjava-kernel/src/main/java/org/dflib/jjava/kernel/execution/JJavaExecutionControl.java
@@ -131,6 +131,18 @@ class JJavaExecutionControl extends DirectExecutionControl {
         return id;
     }
 
+    private RunException wrapInRunException(Throwable cause) {
+        if (cause instanceof SPIResolutionException) {
+            return new ResolutionException(((SPIResolutionException) cause).id(), cause.getStackTrace());
+        }
+
+        UserException ue = new UserException(String.valueOf(cause.getMessage()), cause.getClass().getName(), cause.getStackTrace());
+        if (cause.getCause() != null) {
+            ue.initCause(wrapInRunException(cause.getCause()));
+        }
+        return ue;
+    }
+
     private Object doInvoke(String id, Method doitMethod) throws Exception {
 
         Future<Object> task = isNestedCall()
@@ -160,10 +172,8 @@ class JJavaExecutionControl extends DirectExecutionControl {
             }
             if (cause == null) {
                 throw new UserException("null", "Unknown Invocation Exception", e.getStackTrace());
-            } else if (cause instanceof SPIResolutionException) {
-                throw new ResolutionException(((SPIResolutionException) cause).id(), cause.getStackTrace());
             } else {
-                throw new UserException(String.valueOf(cause.getMessage()), cause.getClass().getName(), cause.getStackTrace());
+                throw wrapInRunException(cause);
             }
         } catch (TimeoutException e) {
             String message = String.format("Execution timed out after configured timeout of %d %s.",


### PR DESCRIPTION
## What does this PR do?
Fixes #118.

## Details
The root cause is that JShell's `UserException` class doesn't preserve the `Throwable cause` field during serialization, it only carries `message`, `causeExceptionClass`, and `stackTrace` elements. When the exception chain is converted to `EvalException` by JShell, intermediate causes are discarded.

We can recursively wrap the entire exception cause chain in `UserException`'s using `initCause()` before passing to JShell. This allows JShell to properly reconstruct the full exception chain.

## Testing
Tested manually in jupyter notebook with a test snippet. Full exception chain is now displayed.